### PR TITLE
Add ours merge driver configuration to workflow files

### DIFF
--- a/.github/workflows/merge-nnue-to-bookgen.yml
+++ b/.github/workflows/merge-nnue-to-bookgen.yml
@@ -32,11 +32,17 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      # Step 3: Fetch nnue branch
+      # Step 3: Configure ours merge driver
+      - name: Configure ours merge driver
+        run: |
+          git config merge.ours.driver true
+          git config merge.ours.name "Keep ours merge driver"
+
+      # Step 4: Fetch nnue branch
       - name: Fetch nnue branch
         run: git fetch origin nnue:nnue
 
-      # Step 4: Merge nnue into bookgen
+      # Step 5: Merge nnue into bookgen
       - name: Merge nnue into bookgen
         id: merge
         run: |
@@ -50,14 +56,14 @@ jobs:
             exit 1
           fi
 
-      # Step 5: Push changes to bookgen
+      # Step 6: Push changes to bookgen
       - name: Push changes to bookgen
         if: steps.merge.outputs.merge_status == 'success'
         run: |
           echo "Pushing merged changes to bookgen..."
           git push origin bookgen
 
-      # Step 6: Report status
+      # Step 7: Report status
       - name: Merge successful
         if: steps.merge.outputs.merge_status == 'success'
         run: echo "Successfully merged nnue into bookgen and pushed changes."

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -40,7 +40,13 @@ jobs:
           persist-credentials: true
           token: ${{ secrets.WORKFLOW_TOKEN }}
 
-      # Step 2: Sync upstream changes
+      # Step 2: Configure ours merge driver
+      - name: Configure ours merge driver
+        run: |
+          git config merge.ours.driver true
+          git config merge.ours.name "Keep ours merge driver"
+
+      # Step 3: Sync upstream changes
       - name: Sync upstream changes
         id: sync
         uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.1
@@ -52,11 +58,11 @@ jobs:
           test_mode: ${{ inputs.test_mode || false }}
           shallow_since: ${{ inputs.shallow_since || '1 month ago' }}
 
-      # Step 3: Display sync status
+      # Step 4: Display sync status
       - name: New commits found
         if: steps.sync.outputs.has_new_commits == 'true'
         run: echo "New commits were found and synced from upstream."
-      
+
       - name: No new commits
         if: steps.sync.outputs.has_new_commits == 'false'
         run: echo "Repository is already up to date with upstream."


### PR DESCRIPTION
Configure the 'ours' merge driver in both upstream-sync and merge-nnue-to-bookgen workflows to handle merge conflicts by keeping our version of files when conflicts occur.