### PR TITLE
Update CI to use OIDC for npm publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,11 +109,29 @@ jobs:
           name: no-embedded-nnue
           path: src/emscripten/public/stockfish*
 
-      - name: Publish to NPM
-        if: startsWith(github.ref, 'refs/tags/')
+  publish:
+    runs-on: ubuntu-24.04
+    needs: [lint, test, test-no-embedded-nnue]
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      id-token: write  # Required for OIDC authentication to npm
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: no-embedded-nnue
+          path: src/emscripten/public
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm to support OIDC
+        run: npm install -g npm@latest
+
+      - name: Publish to NPM using OIDC
         working-directory: src/emscripten/public
-        run: |
-          npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-          npm publish
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish


### PR DESCRIPTION
- Remove token-based authentication (NPM_TOKEN secret) from test-no-embedded-nnue job
- Create separate publish job that only runs on tag pushes
- Add OIDC permissions (id-token: write, contents: read) for npm authentication
- Make publish job depend on successful completion of lint, test, and test-no-embedded-nnue jobs
- Use actions/setup-node with registry-url for OIDC support
- Update npm to latest version to ensure OIDC compatibility
- Download artifacts from test-no-embedded-nnue job for publishing

This makes the publishing process more transparent and secure by:
1. Separating publish concerns from testing
2. Using OIDC instead of long-lived tokens
3. Only publishing when all CI jobs pass successfully