### PR TITLE
Fix npm provenance verification by adding repository URL

### DIFF
--- a/src/emscripten/public/package.json
+++ b/src/emscripten/public/package.json
@@ -5,6 +5,10 @@
   "author": "Fabian Fichter",
   "license": "GPL-3.0",
   "homepage": "https://github.com/ianfab/fairy-stockfish.wasm",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fairy-stockfish/fairy-stockfish.wasm"
+  },
   "files": [
     "AUTHORS",
     "Copying.txt",


### PR DESCRIPTION
Add repository field to package.json with the correct GitHub URL. This resolves the npm 422 error during publishing where provenance verification was failing due to missing repository information.