### PR TITLE
Fix npm package missing AUTHORS and Copying.txt files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,11 @@ jobs:
           name: no-embedded-nnue
           path: src/emscripten/public
 
+      - name: Copy documentation files for npm package
+        run: |
+          cp AUTHORS src/emscripten/public/
+          cp Copying.txt src/emscripten/public/
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'


### PR DESCRIPTION
After the OIDC refactoring in b754f53, the publish job now runs separately and only has the build artifacts downloaded to src/emscripten/public. The AUTHORS and Copying.txt files from the repository root were no longer being included in the published npm package.

This fix copies AUTHORS and Copying.txt from the repository root to src/emscripten/public before publishing, ensuring they are included in the npm package as specified in package.json.